### PR TITLE
Shift and Restyle Chat Image Close Button

### DIFF
--- a/src/css/partials/_chat.scss
+++ b/src/css/partials/_chat.scss
@@ -41,10 +41,18 @@
 		.plugpro-chat-image-close{
 			cursor: pointer;
 			display: none;
-			height: 34px;
 			position: absolute;
-			right: 0;
-			width: 34px;
+			left: 0;
+			width: 1em;
+			height: 1em;
+			font-family: "times new roman", arial;
+			font-size: 1.25rem;
+			line-height: 1;
+			text-align: center;
+			color: #fff;
+			background: rgba(255,0,0,0.5);
+			padding: .05em .1em .05em 0;
+			text-shadow: 0 .05em .1em rgba(0,0,0,0.5);
 		}
 	}
 }

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -21,9 +21,7 @@ __p += '<span class="plugpro-chat-image-container">\n\t<span class="plugpro-chat
 ((__t = ( imgUrl )) == null ? '' : __t) +
 '</a></span>\n\t<img src="' +
 ((__t = ( chromeDir )) == null ? '' : __t) +
-'/images/spinner.gif" class="plugpro-chat-image-spinner" alt="chat image">\n\t<div class="plugpro-image-wrapper">\n\t\t<img class="plugpro-chat-image-close" src="' +
-((__t = ( chromeDir )) == null ? '' : __t) +
-'/images/close.png">\n\t</div>\n</span>';
+'/images/spinner.gif" class="plugpro-chat-image-spinner" alt="chat image">\n\t<div class="plugpro-image-wrapper">\n\t\t<div class="plugpro-chat-image-close">&times;</div>\n\t</div>\n</span>';
 
 }
 return __p


### PR DESCRIPTION
Replaced jpg icon with css-only button and moved it to the top left of the image to avoid being overlapped by the delete button.